### PR TITLE
chore: upgrade to react-email 6

### DIFF
--- a/emails/welcome.tsx
+++ b/emails/welcome.tsx
@@ -10,7 +10,7 @@ import {
   Section,
   Tailwind,
   Text,
-} from '@react-email/components';
+} from 'react-email';
 import { getT } from '@/i18n/get-t';
 import type { Locale } from '@/i18n/i18n';
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@react-email/components": "1.0.1",
+    "@react-email/ui": "6.0.0",
     "i18next": "25.7.3",
     "i18next-resources-to-backend": "1.2.1",
     "next": "16.0.7",
@@ -19,10 +19,9 @@
     "resend": "6.5.2"
   },
   "devDependencies": {
-    "@react-email/preview-server": "5.0.5",
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.1",
-    "react-email": "5.0.5",
+    "react-email": "6.0.0",
     "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
Upgrades to [react-email 6](https://react.email/docs/getting-started/updating-react-email#update-from-react-email-5-0-to-6-0).

- Remove `@react-email/components` and `@react-email/preview-server`
- Add `react-email@6` and `@react-email/ui@6`
- Update imports in `emails/welcome.tsx` from `@react-email/components` to `react-email`