### PR TITLE
chore: use depot runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   build:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-22.04-2
     container:
       image: node:24
     steps:

--- a/.github/workflows/email-build.yml
+++ b/.github/workflows/email-build.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   email-build:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-22.04-2
     container:
       image: node:24
     steps:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, edited, synchronize]
 jobs:
   pr-title-check:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-22.04-2
     container:
       image: node:24
     steps:


### PR DESCRIPTION
## Summary

- Migrate GitHub Actions from `buildjet-4vcpu-ubuntu-2204` to `depot-ubuntu-22.04-2` to align with dashboard patterns